### PR TITLE
Feature: Added Command Line Arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,27 @@
 /hugo_site/content/posts
 /hugo_site/public
 /hugo_site/content/rhinocommon
+
+# remove OS files
+desktop.ini
+.DS_Store
+
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+# Dump file
+*.stackdump
+# Folder config file
+[Dd]esktop.ini
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+# Windows shortcuts
+*.lnk

--- a/README.md
+++ b/README.md
@@ -10,3 +10,17 @@ https://mcneel-apidocs.herokuapp.com/api/rhinocommon/
 
 Instructions for building and testing the quasar site can be found at
 [quasar site readme](quasar_site/readme.md)
+
+
+## Usage
+
+```shell
+$ api_docify --name=<proj_name> <proj_path> <proj_output_js>
+$ api_docify --name=<proj_name> <proj_path> <proj_output_js> <examples_path> <examples_output_js>
+```
+
+**Example**
+
+```shell
+$ api_docify.exe --name="RhinoCommon" "%RHINO4SRC%/rhinocommon/dotnet" "src/modules/docify/quasar_site/src/RhinoCommonApi.js"
+```

--- a/src/api_docify.csproj
+++ b/src/api_docify.csproj
@@ -58,6 +58,9 @@
     <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="docopt.net">
+      <Version>0.6.1.10</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp">
       <Version>3.6.0-2.final</Version>
     </PackageReference>


### PR DESCRIPTION
```
Usage:
      {name} --name=<proj_name> <proj_path> <proj_output_js>
      {name} --name=<proj_name> <proj_path> <proj_output_js> <examples_path> <examples_output_js>

    Options:
      -h --help                 Show this help
      -V --version              Show version
      --name=<proj_name>        Project name
      <proj_path>               Project directory containing C# source files
      <proj_output_js>          Output javascript file
      <examples_path>           Examples directory containing example source files
      <examples_output_js>      Output javascript file for examples
```